### PR TITLE
Freeze version numbers 

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -2,10 +2,10 @@ name: pinns-for-comp-mech
 channels:
   - conda-forge 
 dependencies:
-  - python=3.12
+  - python=3.8.15
   - pip
-  - tensorflow
-  - tensorflow-probability
+  - tensorflow==2.7.0
   - tf-keras
   - pip:
+    - scipy==1.7.3
     - -e .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ keywords = ["physics-informed neural networks", "computational mechanics", "cont
 readme = "README.md"
 
 # Dependencies of the project that need to be installed to use this project properly
-requires-python = ">= 3.8"
+requires-python = "==3.8.15"
 dependencies = [
+  "scipy==1.7.3",
   "deepxde",
   "gmsh",
   "matplotlib",
@@ -41,8 +42,7 @@ dev = [
   "sphinx"
 ]
 tf = [
-  "tensorflow",
-  "tensorflow-probability[tf]"
+  "tensorflow==2.7.0",
 ]
 torch = [
   "torch"


### PR DESCRIPTION
@SiVoelkl noticed today that with the current defaults of python, tensorflow and SciPy there is a problem when using LBFGS where the optimization terminates after only a handful of steps without any significant improvement of the overall loss.

Thanks to @tsarikahin we were able to identify a working combination of versions of our models so we adapted the dependencies to be able to still successfully train the models from the examples.